### PR TITLE
fast negative sampling tool

### DIFF
--- a/Dataset.py
+++ b/Dataset.py
@@ -64,7 +64,7 @@ class Dataset(object):
             while line != None and line != "":
                 arr = line.split("\t")
                 negatives = []
-                for x in arr[1: ]:
+                for x in arr[2: ]:
                     negatives.append(int(x))
                 negativeList.append(negatives)
                 line = f.readline()

--- a/convert.py
+++ b/convert.py
@@ -38,27 +38,43 @@ parser.add_argument('--dataset', nargs='?', default='ml-20m', choices=['ml-20m']
 parser.add_argument('--num-train', type=int, default=19000000,
                     help='number of data for training')
 parser.add_argument('--no-negative', action='store_true', help="write no negative examples")
-parser.add_argument('--negative-num', type=int, default=99,
+parser.add_argument('--negative-num', type=int, default=999,
                     help='number of negatives per example')
 
 def get_movielens_data(data_dir, dataset):
     if not os.path.exists(data_dir + '%s.zip' % dataset):
         os.mkdir(data_dir)
         urllib.request.urlretrieve('http://files.grouplens.org/datasets/movielens/%s.zip' % dataset, data_dir + dataset + '.zip')
-    with zipfile.ZipFile(data_dir + "%s.zip" % dataset, "r") as f:
-        f.extractall(data_dir + "./")
+        with zipfile.ZipFile(data_dir + "%s.zip" % dataset, "r") as f:
+            f.extractall(data_dir + "./")
 
-def write_negative_examples(filename, val_data, max_items, negative_num=99):
-    val_data = valid_data.as_matrix()
-    with open(filename, "a+") as f:
-        for index in range(val_data.shape[0]):
-            f.write('('+str(val_data[index,0])+str(',')+str(val_data[index,1])+')')
-            for t in range(99):
-                j = np.random.randint(max_items)
-                while val_data[(val_data[:,0]==index) & (val_data[:,1]==j)].shape[0] != 0:
-                    j = np.random.randint(max_items)
-                f.write('\t'+str(j))
-            f.write('\n')
+def write_negative_examples(filename, val_data, max_items, negative_num=999):
+    f=open(filename,'a')
+    epoch=val_data.shape[0]//1000 +1 # number of blocks
+    for i in range(epoch):
+        print("\r epoch %d" % i)
+        start=i*1000
+        if i == epoch-1:
+            end=-1 # in last cycle, the block is less then 1000
+        end=(i+1)*1000
+        val_mat = val_data[start:end].as_matrix().astype(np.int)[:,:2]
+        neg_mat=[]
+        for index in range(val_mat.shape[0]):
+            neg_data=[]
+            pos_items=np.repeat(val_mat[index,1], negative_num) # 999个positve item
+            while len(pos_items) > 0: 
+                neg_items = np.random.randint(0, high=max_items, size=len(pos_items))
+                neg_mask = pos_items != neg_items # logical == 
+                neg_data.append(neg_items[neg_mask])
+                
+                pos_items = pos_items[np.logical_not(neg_mask)]
+            neg_data=np.concatenate(neg_data)
+            neg_mat.append(neg_data)
+
+        neg_mat = np.hstack([val_mat,neg_mat]) # concatanate
+        np.savetxt(f, neg_mat, delimiter='\t', fmt="%d")
+    f.close()
+
 
 if __name__ == '__main__':
 
@@ -87,12 +103,12 @@ if __name__ == '__main__':
     valid_data['userId'] = valid_data.loc[:,'userId'] - 1
     valid_data['movieId'] = valid_data.loc[:,'movieId'] - 1
 
-    logging.info('save training dataset into %s' % (data_dir + dataset + '/ml-20m.train.rating'))
-    train_data.to_csv(data_dir + dataset + '/ml-20m.train.rating', sep='\t', header=False, index=False)
-    logging.info('save validation dataset into %s' % (data_dir + dataset + '/ml-20m.test.rating'))
-    valid_data.to_csv(data_dir + dataset + '/ml-20m.test.rating', sep='\t', header=False, index=False)
+    logging.info('save training dataset into %s' % (data_dir + dataset + '.train.rating'))
+    train_data.to_csv(data_dir + dataset + '.train.rating', sep='\t', header=False, index=False)
+    logging.info('save validation dataset into %s' % (data_dir + dataset + '.test.rating'))
+    valid_data.to_csv(data_dir + dataset + '.test.rating', sep='\t', header=False, index=False)
 
     if not args.no_negative:
-        logging.info('save negative dataset into %s' % (data_dir + dataset + '/ml-20m.test.negative'))
-        write_negative_examples(data_dir + dataset + '/ml-20m.test.negative',
+        logging.info('save negative dataset into %s' % (data_dir + dataset + '.test.negative'))
+        write_negative_examples(data_dir + dataset + '.test.negative',
                                 val_data=valid_data, max_items=max_items, negative_num=negative_num)

--- a/evaluate.py
+++ b/evaluate.py
@@ -77,7 +77,7 @@ def eval_one_rating(idx):
     # Get prediction scores
     map_item_score = {}
     users = np.full(len(items), u, dtype = 'int32')
-    iter_eval = get_eval_iters(users, items, batch_size=100)
+    iter_eval = get_eval_iters(users, items, batch_size=1000)
     predictions = _model.predict(iter_eval)
     for i in range(len(items)):
         item = items[i]


### PR DESCRIPTION
1. The form of the converted ml-20m.test.negative is: the first column is user, the second column is positive item, the nest 999 columns are negative items. Thus,  in _def load_negative_file_ , the negative file should begin from arr[2:] not arr[1:]

2. There's an error when running convert.py if we has downloaded ml-20m data before, thus a tiny bug is fixed in _def get_movielens_data_

3. Both train_ncf and eval_ncf has the default running path data_dir + dataset, that is, "/data/ml-20m.xxx" not "/data/ml-20m/ml-20m.xxx". So the the path of data preparation is corrected for convenience. 

4. For 99 negatives before, batch_size=100 is a user to compute Hit Ratio, while for 999 ones, batch_size=1000 is a user.  Thus _get_eval_iters_ is modified. 